### PR TITLE
support export Classes

### DIFF
--- a/example/generated-code/export-class.js.flow
+++ b/example/generated-code/export-class.js.flow
@@ -1,0 +1,3 @@
+// @flow
+declare export class Class1 {}
+declare export default class Class2 {}

--- a/example/orginal-code/export-class.js
+++ b/example/orginal-code/export-class.js
@@ -1,0 +1,9 @@
+// @flow
+
+export class Class1 {
+    // some code
+}
+
+export default class Class2 {
+    // some code
+}

--- a/src/visitior.js
+++ b/src/visitior.js
@@ -127,6 +127,12 @@ export const visitor = options => {
             if (path.node.implements) {
                 declareClass.implements = path.node.implements;
             }
+
+            if (isExportDeclaration(path.parentPath)) {
+                const declareExportDeclaration = transformToDeclareExportDeclaration(path.parentPath, declareClass);
+                path.parentPath.replaceWith(declareExportDeclaration);
+            }
+
             path.replaceWith(declareClass);
         },
         ArrowFunctionExpression(path) {

--- a/test/fixtures/declare-class-export/.babelrc
+++ b/test/fixtures/declare-class-export/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "../../../src/plugin"
+  ]
+}

--- a/test/fixtures/declare-class-export/code.js
+++ b/test/fixtures/declare-class-export/code.js
@@ -1,0 +1,9 @@
+// @flow
+
+export class foo {
+
+}
+
+export default class foo2 {
+
+}

--- a/test/fixtures/declare-class-export/output.js
+++ b/test/fixtures/declare-class-export/output.js
@@ -1,0 +1,3 @@
+// @flow
+declare export class foo {}
+declare export default class foo2 {}


### PR DESCRIPTION
### Expected Behaviour
`export class Foo {}` -> `declare export class foo {}`
`export class default Foo {}` -> `declare export default class foo {}`

### Actual Behaviour
```
gen-flow-files/node_modules/@babel/types/lib/definitions/utils.js:131
      throw new TypeError(`Property ${key} of ${node.type} expected node to be of a type ${JSON.stringify(types)} ` + `but instead got ${JSON.stringify(val && val.type)}`);
      ^

TypeError: Property declaration of ExportDefaultDeclaration expected node to be of a type ["FunctionDeclaration","TSDeclareFunction","ClassDeclaration","Expression"] but instead got "DeclareClass"
```