### PR TITLE
support untyped class properties

### DIFF
--- a/example/generated-code/class-props.js.flow
+++ b/example/generated-code/class-props.js.flow
@@ -1,5 +1,5 @@
 // @flow
-declare class ClassStaticProp {
+declare class ClassProps {
   prop1: any,
   prop2: string,
   static prop3: any,

--- a/example/generated-code/class-props.js.flow
+++ b/example/generated-code/class-props.js.flow
@@ -1,0 +1,9 @@
+// @flow
+declare class ClassStaticProp {
+  prop1: any,
+  prop2: string,
+  static prop3: any,
+  static prop4: string,
+  prop5: any,
+  static prop6: any,
+}

--- a/example/orginal-code/class-props.js
+++ b/example/orginal-code/class-props.js
@@ -1,6 +1,6 @@
 // @flow
 
-class ClassStaticProp {
+class ClassProps {
     prop1 = "prop1";
     prop2: string = "prop2";
     static prop3 = "prop3";

--- a/example/orginal-code/class-props.js
+++ b/example/orginal-code/class-props.js
@@ -1,0 +1,10 @@
+// @flow
+
+class ClassStaticProp {
+    prop1 = "prop1";
+    prop2: string = "prop2";
+    static prop3 = "prop3";
+    static prop4: string = "prop4";
+    prop5 = () => {};
+    static prop6 = param1 => {};
+}

--- a/src/visitior.js
+++ b/src/visitior.js
@@ -103,7 +103,8 @@ export const visitor = options => {
                     if (t.isClassProperty(bodyMember)) {
                         const objectTypeProperty = t.objectTypeProperty(
                             bodyMember.key,
-                            bodyMember.typeAnnotation.typeAnnotation
+                            (bodyMember.typeAnnotation && bodyMember.typeAnnotation.typeAnnotation) ||
+                                t.anyTypeAnnotation()
                         );
                         objectTypeProperty.method = false;
                         objectTypeProperty.static = bodyMember.static;

--- a/test/fixtures/declare-class-property/code.js
+++ b/test/fixtures/declare-class-property/code.js
@@ -3,7 +3,12 @@
 class URL {
     url: string;
 
+    static defaults: Object;
+
     toString(): string {
         return this.url;
     }
+
+    static create(){}
+
 }

--- a/test/fixtures/declare-class-property/output.js
+++ b/test/fixtures/declare-class-property/output.js
@@ -1,5 +1,7 @@
 // @flow
 declare class URL {
   url: string,
+  static defaults: Object,
   toString(): string,
+  static create(): any,
 }


### PR DESCRIPTION
### Expected Behaviour

` class ClassProps { prop1 = "prop1"; static prop3 = "prop3"; }` -> `declare class ClassProps { prop1: any, static prop3: any,}`

### Actual Behaviour
```
TypeError: Property value of ObjectTypeProperty expected node to be of a type ["FlowType"] but instead got null
```