### PR TITLE
Fix: export not named function or class 

### DIFF
--- a/example/generated-code/no-name-class.js.flow
+++ b/example/generated-code/no-name-class.js.flow
@@ -1,0 +1,2 @@
+// @flow
+declare export default class {}

--- a/example/generated-code/no-name-function.js.flow
+++ b/example/generated-code/no-name-function.js.flow
@@ -1,0 +1,2 @@
+// @flow
+declare export default function (one: any, two: number, three?: string, ...rest: Array<number>): string;

--- a/example/orginal-code/no-name-class.js
+++ b/example/orginal-code/no-name-class.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default class {
+    // some code
+}

--- a/example/orginal-code/no-name-function.js
+++ b/example/orginal-code/no-name-function.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default function(one: any, two: number, three?: string, ...rest: Array<number>): string {
+    // some code
+}

--- a/src/visitior.js
+++ b/src/visitior.js
@@ -1,6 +1,7 @@
 const t = require("@babel/types");
 
 const FLOW_DIRECTIVE = /(@flow(\s+(strict(-local)?|weak))?|@noflow)/;
+const emptyIdentifier = { type: "Identifier", name: "" };
 
 const transformFunctionExpressionParam = (param, id) => {
     if (t.isAssignmentPattern(param)) {
@@ -76,7 +77,7 @@ export const visitor = options => {
         },
         FunctionDeclaration(path) {
             if (skipTransform) return;
-            const declareFunction = t.declareFunction(path.node.id);
+            const declareFunction = t.declareFunction(path.node.id || emptyIdentifier);
             const functionTypeAnnotation = transformToFunctionTypeAnnotation(path.node);
             declareFunction.id.typeAnnotation = t.typeAnnotation(functionTypeAnnotation);
 
@@ -113,7 +114,12 @@ export const visitor = options => {
                 })
                 .filter(member => !!member);
             const objectTypeAnnotation = t.objectTypeAnnotation(properties);
-            const declareClass = t.declareClass(path.node.id, path.node.typeParameters, [], objectTypeAnnotation);
+            const declareClass = t.declareClass(
+                path.node.id || emptyIdentifier,
+                path.node.typeParameters,
+                [],
+                objectTypeAnnotation
+            );
 
             if (path.node.superClass) {
                 declareClass.extends = [

--- a/test/fixtures/declare-class-noname-export/.babelrc
+++ b/test/fixtures/declare-class-noname-export/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "../../../src/plugin"
+  ]
+}

--- a/test/fixtures/declare-class-noname-export/code.js
+++ b/test/fixtures/declare-class-noname-export/code.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default class {
+
+}

--- a/test/fixtures/declare-class-noname-export/output.js
+++ b/test/fixtures/declare-class-noname-export/output.js
@@ -1,0 +1,2 @@
+// @flow
+declare export default class {}

--- a/test/fixtures/declare-function-noname-export/.babelrc
+++ b/test/fixtures/declare-function-noname-export/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "../../../src/plugin"
+  ]
+}

--- a/test/fixtures/declare-function-noname-export/code.js
+++ b/test/fixtures/declare-function-noname-export/code.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default function () {
+
+}

--- a/test/fixtures/declare-function-noname-export/output.js
+++ b/test/fixtures/declare-function-noname-export/output.js
@@ -1,0 +1,2 @@
+// @flow
+declare export default function (): any;


### PR DESCRIPTION
### Expected Behaviour
`export default class {}` -> `declare export default class {}`
`export default function(){}` -> `declare export default function():any`

### Current Behaviour
```
gen-flow-files/node_modules/@babel/types/lib/definitions/utils.js:131
      throw new TypeError(`Property ${key} of ${node.type} expected node to be of a type ${JSON.stringify(types)} ` + `but instead got ${JSON.stringify(val && val.type)}`);
      ^

TypeError: Property id of DeclareClass expected node to be of a type ["Identifier"] but instead got null
```