### PR TITLE
Fix when class extends an expression 

### DIFF
--- a/example/generated-code/class-extends.js.flow
+++ b/example/generated-code/class-extends.js.flow
@@ -1,0 +1,4 @@
+// @flow
+declare class Component1 extends Component {}
+declare class Component2 extends React.Component {}
+declare class Component3 extends A.B.C {}

--- a/example/orginal-code/class-extends.js
+++ b/example/orginal-code/class-extends.js
@@ -1,0 +1,7 @@
+// @flow
+
+class Component1 extends Component {}
+
+class Component2 extends React.Component {}
+
+class Component3 extends A.B.C {}

--- a/src/visitior.js
+++ b/src/visitior.js
@@ -47,6 +47,16 @@ const transformToDeclareExportDeclaration = (path, declaration) => {
     return declareExportDeclaration;
 };
 
+const transformToIdentifierString = memberExpression => {
+    if (t.isIdentifier(memberExpression)) {
+        return memberExpression.name;
+    }
+
+    return `${transformToIdentifierString(memberExpression.object)}.${transformToIdentifierString(
+        memberExpression.property
+    )}`;
+};
+
 export const visitor = options => {
     let skipTransform = false;
     const changeSkipTransform = newValue => {
@@ -124,7 +134,9 @@ export const visitor = options => {
             if (path.node.superClass) {
                 declareClass.extends = [
                     t.interfaceExtends(
-                        t.identifier(path.node.superClass.name),
+                        t.isIdentifier(path.node.superClass)
+                            ? path.node.superClass
+                            : t.identifier(transformToIdentifierString(path.node.superClass)),
                         (path.node.superTypeParameters &&
                             t.typeParameterInstantiation(path.node.superTypeParameters.params)) ||
                             undefined

--- a/test/fixtures/declare-class-extends/code.js
+++ b/test/fixtures/declare-class-extends/code.js
@@ -6,3 +6,9 @@ class URL extends React$Component<{x: string}> {
         return null;
     }
 }
+
+class Component1 extends Component {}
+
+class Component2 extends React.Component<Props, State> {}
+
+class Component3 extends A.B.C<{x: string}> {}

--- a/test/fixtures/declare-class-extends/output.js
+++ b/test/fixtures/declare-class-extends/output.js
@@ -4,3 +4,8 @@ declare class URL extends React$Component<{
 }> {
   render(): any
 }
+declare class Component1 extends Component {}
+declare class Component2 extends React.Component<Props, State> {}
+declare class Component3 extends A.B.C<{
+  x: string
+}> {}


### PR DESCRIPTION
Extending expression like `React.Component` throws an exception.

### Expected Behaviour ###
`class C1 extends React.Component{}` -> `declare class Component2 extends React.Component{}`

### Current Behaviour ###
```
TypeError: Property name expected type of string but got null
    at validate (<cwd>/node_modules/@babel/types/lib/definitions/utils.js:164:13)
```